### PR TITLE
Document dependency on rollup-plugin-css-only for rollup usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ export default defineConfig({
 ```ts
 // rollup.config.js
 import LightningCSS from 'unplugin-lightningcss/rollup'
+import css from 'rollup-plugin-css-only'
 
 export default {
-  plugins: [LightningCSS()],
+  plugins: [LightningCSS(), css()],
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ export default defineConfig({
 <details>
 <summary>Rollup</summary><br>
 
+Since Rollup does not support CSS out of the box, you need to use a CSS plugin like [`rollup-plugin-css-only`](https://github.com/thgh/rollup-plugin-css-only).
+
 ```ts
 // rollup.config.js
-import LightningCSS from 'unplugin-lightningcss/rollup'
 import css from 'rollup-plugin-css-only'
+import LightningCSS from 'unplugin-lightningcss/rollup'
 
 export default {
   plugins: [LightningCSS(), css()],


### PR DESCRIPTION
### Description

Without this plugin there is a rollup error when running

```
Error [RollupError]: styles.css (1:0): Expression expected (Note that you need plugins to import files that are not JavaScript)
```

### Linked Issues

n/a


### Additional context

The tests of this package also use this plugin: https://github.com/unplugin/unplugin-lightningcss/blob/04728609908a27949d94ab22c30e687d1392eecb/tests/transform.test.ts#L21

which also proves this plugin is a must-have
