### PR TITLE
Fix CSS modules classnames cause build failures

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -42,17 +42,23 @@ export async function transformCssModule(
   const compiledId = actualId
     .replaceAll('\\', '/')
     .replace(/\.module\.css$/, '.module_built.css')
+
+  const classes = Object.fromEntries(
+    Object.entries(res.exports ?? {}).map(([key, value]) => [key, value.name]),
+  )
+  let exports = `const classes = ${JSON.stringify(classes)}\nexport default classes\n`
+  const i = 0
+  for (const key of Object.keys(classes)) {
+    const sanitizedKey = `_${key.replaceAll(/\W/g, '_')}${i}`
+    exports +=
+      `\nconst ${sanitizedKey} = classes[${JSON.stringify(key)}]\n` +
+      `export { ${sanitizedKey} as ${JSON.stringify(key)} }\n`
+  }
+
   return {
     code: res.code.toString(),
     map: 'map' in res ? res.map?.toString() : undefined,
     id: compiledId,
-    exports: res.exports
-      ? Object.entries(res.exports)
-          .map(
-            ([name, { name: className }]) =>
-              `export const ${name} = "${className}";`,
-          )
-          .join('\n')
-      : '',
+    exports,
   }
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This applies sanitization to CSS module class names, so they don't fail build

### Linked Issues

#31 

### Additional context

As discussed in the linked issue the approach similar to the [JSON plugin](https://github.com/unplugin/unplugin-oxc/blob/43301e27ba276d50b8e9068b874b7287ebfe1746/src/index.ts#L109-L117) is taken.

We export classes with their original names, but avoid any syntax errors. 

In addition the default export was added containing the classes mapping object.